### PR TITLE
update zendesk fork of eslintrb

### DIFF
--- a/eslintrb.gemspec
+++ b/eslintrb.gemspec
@@ -7,9 +7,9 @@ Gem::Specification.new do |s|
   s.version     = Eslintrb::VERSION
   s.authors     = ["ocke", "stereobooster"]
   s.email       = ["ocke@exploder.nl", "stereobooster@gmail.com"]
-  s.homepage    = "https://github.com/ocke/eslintrb"
+  s.homepage    = "https://github.com/zendesk/eslintrb"
   s.summary     = %q{Ruby wrapper for ESLint}
-  s.description = %q{Ruby wrapper for ESLint. The main difference from eslint gem it does not depend on Java. Instead, it uses ExecJS}
+  s.description = %q{Ruby wrapper for ESLint. Uses ExecJS}
   s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite
### Description

updates the upstream eslint version to v2.6.0
### Risks
- [low] linter may start failing app uploads with validation errors
