### PR TITLE
Replace `last_comment` with `last_description`

### DIFF
--- a/lib/eslintrb/eslinttask.rb
+++ b/lib/eslintrb/eslinttask.rb
@@ -52,7 +52,7 @@ module Eslintrb
     def define # :nodoc:
 
       actual_name = Hash === name ? name.keys.first : name
-      unless ::Rake.application.last_comment
+      unless ::Rake.application.last_description
         desc "Run ESLint"
       end
       task name do


### PR DESCRIPTION
``` bash
$ rake eslint
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
```

This is causing a failure in Heroku deploys with these errors:

``` bash
remote:        Bundle completed (0.48s)
remote:        Cleaning up the bundler cache.
remote: sh: 2: Syntax error: Unterminated quoted string
remote: sh: 2: Syntax error: Unterminated quoted string
remote:  !
remote:  !     Could not detect rake tasks
remote:  !     ensure you can run `$ bundle exec rake -P` against your app
remote:  !     and using the production group of your Gemfile.
remote:  !     rake aborted!
remote:  !     LoadError: cannot load such file -- eslintrb/eslinttask
```
